### PR TITLE
Add dtypes as string attributes of numpy module

### DIFF
--- a/numpy/src/numpy.cpp
+++ b/numpy/src/numpy.cpp
@@ -833,6 +833,9 @@ using ndarray_float = ndarray<float64>;
 PYBIND11_EMBEDDED_MODULE(numpy_bindings, m) {
     m.doc() = "Python bindings for pkpy::numpy::ndarray using pybind11";
 
+    m.attr("int") = "int";
+    m.attr("float64") = "float64";
+    
     py::class_<ndarray_base>(m, "ndarray")
         .def_property_readonly("ndim", &ndarray_base::ndim)
         .def_property_readonly("size", &ndarray_base::size)


### PR DESCRIPTION
```
>>> hasattr(np, 'int')
True
>>> hasattr(np, 'float64')
True
>>> np.array( 3.5 ).dtype == np.float64
True
```